### PR TITLE
Escape quotes in usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In General, basic usage
 | `user` | same as database name |
 | `password` | randomly generated |
 
-And MySQL credentials for new db/user creation will be taken from the MySQL config file `~/.my.cnf`.  
+And MySQL credentials for new db/user creation will be taken from the MySQL config file `~/.my.cnf` (try [`~/my.cnf` on Windows](https://github.com/r-dbi/RMariaDB/issues/74#issuecomment-418712342)).  
 If you don't have one, you can simply create a `.my.cnf` file in home directory, with
 ```
 [client]

--- a/src/mysql-db-user-creator.sh
+++ b/src/mysql-db-user-creator.sh
@@ -169,7 +169,7 @@ Version $VERSION
 
     Examples:
         $(basename $0) --help
-        $(basename $0) [--host="<host-name>"] --database="<db-name>" [--user="<db-user>"] [--pass="<user-password>"]
+        $(basename $0) [--host=\"<host-name>\"] --database=\"<db-name>\" [--user=\"<db-user>\"] [--pass=\"<user-password>\"]
 
 "
     _printPoweredBy


### PR DESCRIPTION
This seems to be necessary for usage in Windows with [Git Bash](https://gitforwindows.org/).