### PR TITLE
Solve "bash line 154: host-name: No such file or directory" with cat << EOF

### DIFF
--- a/src/mysql-db-user-creator.sh
+++ b/src/mysql-db-user-creator.sh
@@ -154,7 +154,8 @@ function generatePassword()
 
 function _printUsage()
 {
-    echo -n "$(basename $0) [OPTION]...
+cat << EOF
+$(basename $0) [OPTION]...
 
 Create MySQL db & user.
 Version $VERSION
@@ -171,7 +172,7 @@ Version $VERSION
         $(basename $0) --help
         $(basename $0) [--host="<host-name>"] --database="<db-name>" [--user="<db-user>"] [--pass="<user-password>"]
 
-"
+EOF
     _printPoweredBy
     exit 1
 }


### PR DESCRIPTION
Multiline echo isn't workable in a bash function unless all the lines are outdent all the way to the left or keep them all indented to line up. However, the best way is to use a cat with EOF. This will solve errors like:

```bash
line 154: host-name: No such file or directory by using cat and EOF
```
